### PR TITLE
Describe operations and events WebTransport is expected to implement

### DIFF
--- a/draft-ietf-webtrans-overview.md
+++ b/draft-ietf-webtrans-overview.md
@@ -338,7 +338,8 @@ abort send side
 : Sends a signal to the peer that the write side of the stream has been aborted.
   Discards the send buffer; if possible, no currently outstanding data is
   transmitted or retransmitted.  An unsigned 8-bit error code can be supplied
-  as a part of the signal to the peer.
+  as a part of the signal to the peer; if omitted, the error code is presumed
+  to be 0.
 
 abort receive side
 : Sends a signal to the peer that the read side of the stream has been aborted.

--- a/draft-ietf-webtrans-overview.md
+++ b/draft-ietf-webtrans-overview.md
@@ -239,9 +239,11 @@ terminate a session
 Any WebTransport protocol SHALL provide the following events:
 
 session terminated event
-: Indicates that the WebTransport session has been terminated, and no user data
-  can be exchanged on it any further.  Similarly to the "terminate a session"
-  operation above, an error code and an error string can be provided.
+: Indicates that the WebTransport session has been terminated, either by the
+  peer or by the local networking stack, and no user data can be exchanged on
+  it any further.  If the session has been terminated as a result of the peer
+  performing the "terminate a session" operation above, a corresponding error
+  code and an error string can be provided.
 
 ## Datagrams  {#features-datagrams}
 
@@ -275,7 +277,7 @@ receive a datagram
 
 get maxiumum datagram size
 : Returns the largest size of the datagram that a WebTransport session is
-  expected to be able to transfer.
+  expected to be able to send.
 
 ## Streams  {#features-streams}
 
@@ -312,7 +314,7 @@ create a bidirectional stream
 : Creates an outgoing bidirectional stream; this operation may block until the
   flow control allows for it to be completed.
 
-receieve a unidirectional stream
+receive a unidirectional stream
 : Removes a stream from the queue of incoming unidirectional streams, if one is
   available.
 
@@ -356,9 +358,9 @@ receive side aborted
   stream.  An unsigned 8-bit error code from the peer may be available.
 
 Data Recvd state reached
-: Indicates that no further data will be transmitted or retransmitted, and that
-  the FIN has been sent.  Data Recvd implies that aborting send-side is a
-  no-op.
+: Indicates that no further data will be transmitted or retransmitted on the
+  local send side, and that the FIN has been sent.  Data Recvd implies that
+  aborting send-side is a no-op.
 
 # Transport Properties
 

--- a/draft-ietf-webtrans-overview.md
+++ b/draft-ietf-webtrans-overview.md
@@ -229,7 +229,7 @@ session:
 
 establish a session
 : Create a new WebTransport session given a URI {{!RFC3986}} and the origin
-  {{!RFC6454}}.
+  {{!RFC6454}} of the requester.
 
 terminate a session
 : Terminate the session while communicating to the peer an unsigned 32-bit
@@ -263,7 +263,7 @@ send.  The size SHOULD be derived from the result of performing path MTU
 discovery.
 
 In the WebTransport model, all of the outgoing and incoming datagrams are
-placed into a size-bound queue (similar to a NIC queue).
+placed into a size-bound queue (similar to a network interface card queue).
 
 Any WebTransport protocol SHALL provide the following operations on the
 session:
@@ -308,11 +308,11 @@ session:
 
 create a unidirectional stream
 : Creates an outgoing unidirectional stream; this operation may block until the
-  flow control allows for it to be completed.
+  flow control of the underlying protocol allows for it to be completed.
 
 create a bidirectional stream
 : Creates an outgoing bidirectional stream; this operation may block until the
-  flow control allows for it to be completed.
+  flow control of the underlying protocol allows for it to be completed.
 
 receive a unidirectional stream
 : Removes a stream from the queue of incoming unidirectional streams, if one is


### PR DESCRIPTION
Currently, in the W3C API draft, we cite the HTTP/3 draft and RFC 9000
directly.  This does not work with WebTransport over HTTP/2, hence we
need for the overview draft to provide a common set of operations that
both H3 and H2 versions of the draft are expected to implement.